### PR TITLE
Implement facebook profile photo access for guardian query

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 export HUBOT_LOG_LEVEL=debug
 export HUBOT_SLACK_TOKEN=
 export REDIS_URL=
+export FB_CLIENT_ID=
+export FB_CLIENT_SECRET=
+export FIREBASE_API_KEY=
+export FIREBASE_AUTH_DOMAIN=
+export FIREBASE_DB_URL=

--- a/bin/hubot
+++ b/bin/hubot
@@ -4,7 +4,7 @@ set -e
 
 npm install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
-if [ "$NODE_ENV" = "development" ]
+if [ "$NODE_ENV" != "production" ]
 then
   . .env
 fi

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Jonathan Chiam <jczjchiam@gmail.com>",
   "description": "Bot for use with accorde guitar ensemble chat on slack",
   "dependencies": {
+    "async": "^2.1.4",
+    "fbgraph": "^1.4.1",
+    "firebase": "^3.6.9",
     "hubot": "^2.19.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-help": "^0.2.0",

--- a/scripts/guardian.js
+++ b/scripts/guardian.js
@@ -6,10 +6,30 @@
 //  hubot guardian reset - dethrone keeper of the key
 //  hubot guardian set <name> - crown the keeper of the key
 //
+// Dependencies:
+//  "async": "^2.1.4"
+//
+// Configuration:
+//  FB_CLIENT_ID
+//  FB_CLIENT_SECRET
+//  FIREBASE_API_KEY
+//  FIREBASE_AUTH_DOMAIN
+//  FIRE_DB_URL
+//
 // Author:
 //  jonathan
 
+const graph = require('fbgraph');
+const firebase = require('firebase');
+const async = require('async');
+
 const REDIS_GUARDIAN_KEY = 'guardian';
+const FIREBASE_CONFIG = {
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.FIREBASE_DB_URL
+};
+firebase.initializeApp(FIREBASE_CONFIG);
 
 module.exports = (robot) => {
   robot.respond(/\bguardian ?(.*)?/i, (res) => {
@@ -30,7 +50,7 @@ module.exports = (robot) => {
             robot.brain.set(REDIS_GUARDIAN_KEY, name);
             res.send(`${name} is now the keeper of the key!`);
           } else {
-            res.send('Set who?');
+            res.send('I\'m not sure who you are trying to set...');
           }
           break;
         default:
@@ -39,11 +59,67 @@ module.exports = (robot) => {
     // hubot guardian - keeper of the key
     } else {
       const guardian = robot.brain.get('guardian');
-      if (guardian) {
-        res.send(guardian);
-      } else {
-        res.send('Keeper of keys unknown...');
+      if (!guardian) {
+        res.send('Keeper of key unknown...');
+        return;
       }
+
+      firebase.auth().signInAnonymously().catch((error) => {
+        res.send(error.code);
+        res.send(error.message);
+      });
+
+      async.waterfall([
+        cb => getFacebookAccessToken(cb),
+        cb => getFacebookID(guardian, cb),
+        (facebookID, cb) => getFacebookProfilePhoto(facebookID, cb),
+        (profilePhotoURL, cb) => prepareGuardianDeclaration(guardian, profilePhotoURL, cb)
+      ], (err, attachments) => {
+        if (err) {
+          res.send(`Error: ${JSON.stringify(err)}`);
+        } else {
+          res.send(attachments);
+        }
+      });
     }
   });
+
+  let getFacebookAccessToken = (callback) => {
+    const url = `https://graph.facebook.com/oauth/access_token?client_id=${process.env.FB_CLIENT_ID}&client_secret=${process.env.FB_CLIENT_SECRET}&grant_type=client_credentials`;
+    robot.http(url).get()((err, resp) => {
+      if (resp.statusCode !== 200) {
+        callback(new Error(`Facebook auth failed...${process.env.FB_CLIENT_ID}`));
+      } else {
+        // graph.setAccessToken(body.split('='[1]));
+        callback(null);
+      }
+    });
+  };
+
+  let getFacebookID = (name, callback) => {
+    firebase.database().ref('/facebook').on('value', (snapshot) => {
+      const facebookID = snapshot.val()[name];
+      callback(null, facebookID);
+    }, err => callback(err, null));
+  };
+
+  let getFacebookProfilePhoto = (facebookID, callback) => {
+    graph.get(`${facebookID}/picture?type=large`, (err, resp) => {
+      if (err) {
+        callback(err, null);
+      } else {
+        callback(null, resp.location);
+      }
+    });
+  };
+
+  let prepareGuardianDeclaration = (name, profilePhotoURL, callback) => {
+    const attachments = [{
+      fallback: `Keeper of the key - ${name}`,
+      title: `Keeper of the key - ${name}`,
+      image_url: profilePhotoURL,
+      footer: 'Brought to you by Accord\u00E9Bot'
+    }];
+    callback(null, attachments);
+  };
 };


### PR DESCRIPTION
- Update environment variables to accept facebook client id and secret for app access token
- Update environment variables for firebase connection
- Guardian query now pulls facebook id info from firebase db
- Guardian query now pulls facebook profile photo and sends attachment to slack