### PR TITLE
Fix firebase related queries always failing on first try

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ hubot guardian - keeper of the key
 hubot guardian reset - dethrone keeper of the key
 hubot guardian set <name> - crown the keeper of the key
 hubot user(s) - full user list with slack IDs
+hubot alias(es) - returns a list of the aliases of all slack users 
 ```
 
 ## Requirements

--- a/scripts/utils/auth.js
+++ b/scripts/utils/auth.js
@@ -8,6 +8,13 @@ const FIREBASE_CONFIG = {
 firebase.initializeApp(FIREBASE_CONFIG);
 
 const authenticateFirebase = (callback) => {
+  const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
+    if (user) {
+      unsubscribe();
+      callback(null);
+    }
+  });
+
   // sign in to firebase if necessary
   if (firebase.auth().currentUser == null) {
     firebase
@@ -15,7 +22,6 @@ const authenticateFirebase = (callback) => {
       .signInWithEmailAndPassword(process.env.FIREBASE_EMAIL, process.env.FIREBASE_EMAIL_PW)
       .catch(error => callback(error));
   }
-  callback(null);
 };
 
 const getFacebookAccessToken = (robot, callback) => {


### PR DESCRIPTION
Firebase related queries always failed on first try due to login not ready.

- Fixed by running callback when `onAuthStateChanged` listener detects successful login
- Listener is removed right before callback